### PR TITLE
fix: fishing getting animation cancelled

### DIFF
--- a/AutoAnimationCancel/AutoAnimationCancel/ModEntry.cs
+++ b/AutoAnimationCancel/AutoAnimationCancel/ModEntry.cs
@@ -27,6 +27,8 @@ namespace AutoAnimationCancel
 
         public bool ShouldAnimationCancel()
         {
+            if (Game1.player.CurrentItem is FishingRod) return false;
+            
             if (Game1.player.CurrentItem is MeleeWeapon w)
             {
                 switch (Game1.player.FarmerSprite.CurrentSingleAnimation)

--- a/AutoAnimationCancel/AutoAnimationCancel/ModEntry.cs
+++ b/AutoAnimationCancel/AutoAnimationCancel/ModEntry.cs
@@ -27,7 +27,10 @@ namespace AutoAnimationCancel
 
         public bool ShouldAnimationCancel()
         {
-            if (Game1.player.CurrentItem is FishingRod) return false;
+            if (Game1.player.CurrentItem is FishingRod)
+            {
+                return false;
+            }
             
             if (Game1.player.CurrentItem is MeleeWeapon w)
             {


### PR DESCRIPTION
Uses the same type checking method as checking for the melee weapon.