### PR TITLE
[VisibleArtifactSpots] feat: Add an option to highlight forageable items, and update HoeDirt highlight logic.

### DIFF
--- a/VisibleArtifactSpots/VisibleArtifactSpots/GenericModConfigMenu.cs
+++ b/VisibleArtifactSpots/VisibleArtifactSpots/GenericModConfigMenu.cs
@@ -19,6 +19,12 @@ namespace VisibleArtifactSpots
         /// <remarks>Each mod can only be registered once, unless it's deleted via <see cref="Unregister"/> before calling this again.</remarks>
         void Register(IManifest mod, Action reset, Action save, bool titleScreenOnly = false);
 
+        /// <summary>Add a section title at the current position in the form.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="text">The title text shown in the form.</param>
+        /// <param name="tooltip">The tooltip text shown when the cursor hovers on the title, or <c>null</c> to disable the tooltip.</param>
+        void AddSectionTitle(IManifest mod, Func<string> text, Func<string> tooltip = null);
+
         /// <summary>Add a boolean option at the current position in the form.</summary>
         /// <param name="mod">The mod's manifest.</param>
         /// <param name="getValue">Get the current value from the mod config.</param>

--- a/VisibleArtifactSpots/VisibleArtifactSpots/ModConfig.cs
+++ b/VisibleArtifactSpots/VisibleArtifactSpots/ModConfig.cs
@@ -21,5 +21,6 @@ namespace VisibleArtifactSpots
         public bool HighlightNonWatered { get; set; } = false;
         public bool HighlightNonFertilized { get; set; } = false;
         public bool HighlightHoeableTile { get; set; } = false;
+        public bool HighlightForageable { get; set; } = false;
     }
 }

--- a/VisibleArtifactSpots/VisibleArtifactSpots/ModEntry.cs
+++ b/VisibleArtifactSpots/VisibleArtifactSpots/ModEntry.cs
@@ -35,6 +35,12 @@ namespace VisibleArtifactSpots
                 save: () => this.Helper.WriteConfig(config)
             );
 
+            configMenu.AddSectionTitle(
+                this.ModManifest,
+                () => "Highlighting Configs",
+                () => "Highlighting configuration options for Visible Artifact Spots."
+            );
+
             configMenu.AddTextOption(
                 this.ModManifest,
                 () => config.HighlightType,
@@ -42,6 +48,12 @@ namespace VisibleArtifactSpots
                 () => "Highlight type",
                 () => "The way to highlight things.",
                 new string[] { "Border", "Bubble", "Both" }
+            );
+
+            configMenu.AddSectionTitle(
+                this.ModManifest,
+                () => "Digspot Options",
+                () => "Options for digspots."
             );
 
             configMenu.AddBoolOption(
@@ -58,6 +70,12 @@ namespace VisibleArtifactSpots
                 (bool val) => config.HighlightSeedSpots = val,
                 () => "Seed Spots",
                 () => "Whether to highlight seed spots."
+            );
+
+            configMenu.AddSectionTitle(
+                this.ModManifest,
+                () => "Debris Options",
+                () => "Options for debris (weeds, twigs, stones)."
             );
 
             configMenu.AddBoolOption(
@@ -82,6 +100,12 @@ namespace VisibleArtifactSpots
                 (bool val) => config.HighlightStones = val,
                 () => "Stones",
                 () => "Whether to highlight stones."
+            );
+
+            configMenu.AddSectionTitle(
+                this.ModManifest,
+                () => "Ore Node Options",
+                () => "Options for ore nodes (copper, iron, gold, iridium, radioactive, cinder)."
             );
 
             configMenu.AddBoolOption(
@@ -132,28 +156,26 @@ namespace VisibleArtifactSpots
                 () => "Whether to highlight cinder nodes."
             );
 
-            configMenu.AddBoolOption(
+            configMenu.AddSectionTitle(
                 this.ModManifest,
-                () => config.HighlightChests,
-                (bool val) => config.HighlightChests = val,
-                () => "Chests (in Volcano Dungeon)",
-                () => "Whether to highlight chests in the Volcano Dungeon."
+                () => "Farming Options",
+                () => "Options for farming-related tiles."
             );
 
             configMenu.AddBoolOption(
                 this.ModManifest,
                 () => config.HighlightNonPlanted,
                 (bool val) => config.HighlightNonPlanted = val,
-                () => "Non-Planted Crops",
-                () => "Whether to highlight tiles with no crops planted."
+                () => "Non-Planted Tilled Tile",
+                () => "Whether to highlight tilled tiles with no crops planted."
             );
 
             configMenu.AddBoolOption(
                 this.ModManifest,
                 () => config.HighlightNonWatered,
                 (bool val) => config.HighlightNonWatered = val,
-                () => "Non-Watered Tiles",
-                () => "Whether to highlight tiles that are not watered."
+                () => "Non-Watered Crops",
+                () => "Whether to highlight tiles that are not watered with crops planted."
             );
 
             configMenu.AddBoolOption(
@@ -161,7 +183,7 @@ namespace VisibleArtifactSpots
                 () => config.HighlightNonFertilized,
                 (bool val) => config.HighlightNonFertilized = val,
                 () => "Non-Fertilized Crops",
-                () => "Whether to highlight tiles that are not fertilized."
+                () => "Whether to highlight tiles that are not fertilized with crops planted."
             );
 
             configMenu.AddBoolOption(
@@ -170,6 +192,28 @@ namespace VisibleArtifactSpots
                 (bool val) => config.HighlightHoeableTile = val,
                 () => "Hoeable Tile",
                 () => "Whether to highlight tiles that are hoeable and are not hoed."
+            );
+
+            configMenu.AddSectionTitle(
+                this.ModManifest,
+                () => "Other Options",
+                () => "Other miscellaneous options."
+            );
+
+            configMenu.AddBoolOption(
+                this.ModManifest,
+                () => config.HighlightForageable,
+                (bool val) => config.HighlightForageable = val,
+                () => "Forageable",
+                () => "Whether to highlight forageable items."
+            );
+
+            configMenu.AddBoolOption(
+                this.ModManifest,
+                () => config.HighlightChests,
+                (bool val) => config.HighlightChests = val,
+                () => "Chests (in Volcano Dungeon)",
+                () => "Whether to highlight chests in the Volcano Dungeon."
             );
         }
 
@@ -217,6 +261,7 @@ namespace VisibleArtifactSpots
                 || (obj.Name == "Stone" && description.Contains("iridium") && config.HighlightIridiumNodes)
                 || (obj.Name == "Stone" && description.Contains("radioactive") && config.HighlightRadioactiveNodes)
                 || (obj.Name == "Stone" && description.Contains("cinder") && config.HighlightCinderNodes)
+                || (obj.IsSpawnedObject == true && config.HighlightForageable)
                 || (obj is Chest chest && !chest.playerChest.Value && !IsChestOpened(chest) && InVolcanoDungeon() && config.HighlightChests)
             );
         }
@@ -264,10 +309,13 @@ namespace VisibleArtifactSpots
         {
             if (terrainFeature is HoeDirt hoeDirt)
             {
+                // Highlight if: (1) no crop is planted and config.HighlightNonPlanted is true
+                // OR (2) a crop is planted but not watered and config.HighlightNonWatered is true
+                // OR (3) a crop is planted but not fertilized and config.HighlightNonFertilized is true
                 return (
                     (hoeDirt.crop is null && config.HighlightNonPlanted)
-                    || (!hoeDirt.isWatered() && config.HighlightNonWatered)
-                    || (hoeDirt.fertilizer.Value is null && config.HighlightNonFertilized)
+                    || (hoeDirt.crop is not null && !hoeDirt.isWatered() && config.HighlightNonWatered)
+                    || (hoeDirt.crop is not null && hoeDirt.fertilizer.Value is null && config.HighlightNonFertilized)
                 );
             }
 


### PR DESCRIPTION
I really love VisibleArtifactSpots, so I tried the Git version, which seems not to have been released on Nexusmods yet.

I found out that highlighting non-watered tilled tiles (HoeDirt) also highlights tiles that I dig for artifacts, which is a bit disturbing.
Also, I added another option to highlight forageable items.

Here is a list of what I changed
- add option to highlight forageables.
- highlight non-watered and non-fertilised tilled tiles only when crops are planted.
- group configs into sections.

Here is my logic for highlighting tilled tiles (HoeDirt)
```
                // Highlight if: (1) no crop is planted and config.HighlightNonPlanted is true
                // OR (2) a crop is planted but not watered and config.HighlightNonWatered is true
                // OR (3) a crop is planted but not fertilized and config.HighlightNonFertilized is true
```